### PR TITLE
解决调用trie_filter_search\trie_filter_search_all进程退出问题

### DIFF
--- a/trie_filter.c
+++ b/trie_filter.c
@@ -244,7 +244,7 @@ PHP_FUNCTION(trie_filter_search)
 	ZEND_FETCH_RESOURCE(trie, Trie *, &trie_resource, -1, 
 			PHP_TRIE_FILTER_RES_NAME, le_trie_filter);
 
-	alpha_text = emalloc(sizeof(AlphaChar) * text_len + 1);
+	alpha_text = emalloc(sizeof(AlphaChar) * (text_len + 1));
 
 	for (i = 0; i < text_len; i++) {
 		alpha_text[i] = (AlphaChar) text[i];
@@ -292,7 +292,7 @@ PHP_FUNCTION(trie_filter_search_all)
 	ZEND_FETCH_RESOURCE(trie, Trie *, &trie_resource, -1, 
 			PHP_TRIE_FILTER_RES_NAME, le_trie_filter);
 
-	alpha_text = emalloc(sizeof(AlphaChar) * text_len + 1);
+	alpha_text = emalloc(sizeof(AlphaChar) * (text_len + 1));
 
 	for (i = 0; i < text_len; i++) {
 		alpha_text[i] = (AlphaChar) text[i];


### PR DESCRIPTION
64位ubuntu机器  PHP 5.3.10-1ubuntu3.15 with Suhosin-Patch 
Configuring for:
PHP Api Version:         20090626
Zend Module Api No:      20090626
Zend Extension Api No:   220090626

emalloc 内存分配大小不正确，efree 时php进程退出
Inferior 1 exited with code 01
